### PR TITLE
GCO_388 Toeleidingsbegrippen toevoegen aan tabel

### DIFF
--- a/catalogusconfiguraties/dso/Stage DSO A.ttl
+++ b/catalogusconfiguraties/dso/Stage DSO A.ttl
@@ -621,18 +621,13 @@ stage:DSOCatalogusUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:catalogusupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:catalogusupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -835,6 +830,56 @@ container:excelupload a elmo:Container;
 	elmo:translator elmo:TableExcelTranslator;
 	rdfs:label "Upload concepten via Excel (.xls)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
 
@@ -846,8 +891,59 @@ container:ttlupload a elmo:Container;
 	elmo:representation elmo:UploadRepresentation;
 	rdfs:label "Upload concepten via RDF (.xml) of Turtle (.ttl)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
+
 # Updatecontainer Excel
 container:excelupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -857,8 +953,59 @@ container:excelupdate a elmo:Container;
     elmo:translator elmo:TableExcelTranslator;
     rdfs:label "Upload een enkel Concept via Excel (.xls)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
+
 # Updatecontainer Turtle
 container:ttlupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -867,6 +1014,56 @@ container:ttlupdate a elmo:Container;
     elmo:representation elmo:UploadRepresentation;
     rdfs:label "Upload een enkel Concept via RDF (.xml) of Turtle (.ttl)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -884,6 +1081,7 @@ container:concepten-put-xml a elmo:Container;
 			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.acceptatie.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-put-xml {
@@ -892,11 +1090,62 @@ container:concepten-put-xml a elmo:Container;
 				FILTER NOT EXISTS {
 					GRAPH doc:mastergraph {
 						?s rdf:type skos:Concept.
+						?s bp4mc2:signature ?sig.
 					}
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die nog niet bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -917,6 +1166,7 @@ container:concepten-post-xml a elmo:Container;
 			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.acceptatie.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-post-xml {
@@ -924,10 +1174,61 @@ container:concepten-post-xml a elmo:Container;
 				}
 				GRAPH doc:mastergraph {
 					?s rdf:type skos:Concept.
+					?s bp4mc2:signature ?sig.
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die al bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.acceptatie.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -984,15 +1285,9 @@ stage:DSOGeneriekeUploadScene a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1292,15 +1587,9 @@ stage:DSOUploadScenePUT a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1544,24 +1833,13 @@ stage:DSODatasetUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:datasetupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:datasetupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
-				}
-				UNION {
-					?s dct:title ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -3091,51 +3369,56 @@ stage:WeergaveTabelConcepten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "00";
+	];
+	elmo:fragment [
 		rdfs:label "Notitie"@nl;
 		elmo:applies-to skos:notation;
-		elmo:index "1";
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -3626,8 +3909,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							)
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3647,8 +3928,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							}
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3716,8 +3995,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -3782,8 +4059,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 			#			}
 			#			FILTER (
 			#				?p != rdf:type
-			#				&& ?p != skos:prefLabel
-			#				&& ?p != skos:notation
 			#				&& ?p != bp4mc2:signature
 			#				&& ?p != dct:type
 			#				&& ?p != skos:member
@@ -3822,58 +4097,47 @@ stage:WeergaveVersiesConceptenQuery a elmo:Query;
 		SELECT DISTINCT (<@IDSUBJECT@> as ?concept) ?concept_label ?graph ?actueeltot
 		WHERE {
 			{
-				{
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						<@IDSUBJECT@> rdfs:isDefinedBy ?actualGraph.
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != ?actualGraph )
-					FILTER( substr("@GRAPH@",2) = "GRAPH@" )
-				}
-				UNION {
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != <@GRAPH@> )
-					FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
-				}
-				FILTER( contains( "@SUBJECT@", "@IDSUBJECT@" ) )
-			}
-			UNION
-			{
 				GRAPH ?graph {
 					<@IDSUBJECT@> rdf:type skos:Concept.
 					?graph prov:generatedAtTime ?concept_label.
-					?graph prov:generatedAtTime ?startTime.
 					OPTIONAL {
 						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
 					}
+				}
+				GRAPH ?actualGraph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?actualGraph prov:generatedAtTime ?startTime.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?endTime.
+					}
 					FILTER (
-						strdt( ?startTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
-						|| (
-							bound( ?actueeltot )
-							&& strdt( ?actueeltot, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						strdt( ?startTime, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						&& (
+							!bound( ?endTime )
+							|| strdt( ?endTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
 						)
 					)
 				}
 				GRAPH doc:mastergraph {
-					?graph dc:isVersionOf doc:mastergraph
+					?graph dc:isVersionOf doc:mastergraph.
+					?actualGraph dc:isVersionOf doc:mastergraph.
 				}
-				FILTER( !contains( "@SUBJECT@", "@IDSUBJECT@" ) )
+				FILTER( ?graph != ?actualGraph )
+				FILTER( substr("@GRAPH@",2) = "GRAPH@" )
+			}
+			UNION {
+				GRAPH ?graph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?graph prov:generatedAtTime ?concept_label.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
+					}
+				}
+				GRAPH doc:mastergraph {
+					?graph dc:isVersionOf doc:mastergraph
+				}	
+				FILTER( ?graph != <@GRAPH@> )
+				FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
 			}
 		}
 		ORDER BY DESC(lcase(?concept_label))
@@ -3928,31 +4192,36 @@ stage:WeergaveTabelWaardelijsten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4106,8 +4375,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4131,8 +4398,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4374,31 +4639,36 @@ stage:WeergaveTabelCollecties a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4548,8 +4818,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4567,8 +4835,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4832,6 +5098,11 @@ stage:WeergaveTabelCatalog a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5012,8 +5283,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5031,8 +5300,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5158,6 +5425,11 @@ stage:WeergaveTabelDataset a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5304,8 +5576,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5331,8 +5601,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5452,6 +5720,11 @@ stage:WeergaveTabelDistribution a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5576,8 +5849,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5595,8 +5866,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5761,6 +6030,11 @@ stage:WeergaveTabelActivity a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5803,6 +6077,11 @@ stage:WeergaveTabelAgent a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5875,8 +6154,6 @@ stage:WeergaveTabelActivityQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -5917,8 +6194,6 @@ stage:WeergaveTabelAgentQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -6083,46 +6358,51 @@ stage:WeergaveTabelShapes a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6282,8 +6562,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6300,8 +6578,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6352,8 +6628,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 						<@SUBJECT@> ?p ?o.
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member
@@ -6477,46 +6751,51 @@ stage:WeergaveTabelNormen a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6675,8 +6954,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6693,8 +6970,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6747,8 +7022,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 						}
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member

--- a/catalogusconfiguraties/dso/Stage DSO O.ttl
+++ b/catalogusconfiguraties/dso/Stage DSO O.ttl
@@ -621,18 +621,13 @@ stage:DSOCatalogusUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:catalogusupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:catalogusupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -835,6 +830,56 @@ container:excelupload a elmo:Container;
 	elmo:translator elmo:TableExcelTranslator;
 	rdfs:label "Upload concepten via Excel (.xls)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
 
@@ -846,8 +891,59 @@ container:ttlupload a elmo:Container;
 	elmo:representation elmo:UploadRepresentation;
 	rdfs:label "Upload concepten via RDF (.xml) of Turtle (.ttl)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
+
 # Updatecontainer Excel
 container:excelupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -857,8 +953,59 @@ container:excelupdate a elmo:Container;
     elmo:translator elmo:TableExcelTranslator;
     rdfs:label "Upload een enkel Concept via Excel (.xls)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
+
 # Updatecontainer Turtle
 container:ttlupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -867,6 +1014,56 @@ container:ttlupdate a elmo:Container;
     elmo:representation elmo:UploadRepresentation;
     rdfs:label "Upload een enkel Concept via RDF (.xml) of Turtle (.ttl)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -884,6 +1081,7 @@ container:concepten-put-xml a elmo:Container;
 			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.ontwikkeling.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-put-xml {
@@ -892,11 +1090,62 @@ container:concepten-put-xml a elmo:Container;
 				FILTER NOT EXISTS {
 					GRAPH doc:mastergraph {
 						?s rdf:type skos:Concept.
+						?s bp4mc2:signature ?sig.
 					}
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die nog niet bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -917,6 +1166,7 @@ container:concepten-post-xml a elmo:Container;
 			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.ontwikkeling.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-post-xml {
@@ -924,10 +1174,61 @@ container:concepten-post-xml a elmo:Container;
 				}
 				GRAPH doc:mastergraph {
 					?s rdf:type skos:Concept.
+					?s bp4mc2:signature ?sig.
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die al bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.ontwikkeling.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -984,15 +1285,9 @@ stage:DSOGeneriekeUploadScene a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1292,15 +1587,9 @@ stage:DSOUploadScenePUT a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1544,24 +1833,13 @@ stage:DSODatasetUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:datasetupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:datasetupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
-				}
-				UNION {
-					?s dct:title ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -3091,51 +3369,56 @@ stage:WeergaveTabelConcepten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "00";
+	];
+	elmo:fragment [
 		rdfs:label "Notitie"@nl;
 		elmo:applies-to skos:notation;
-		elmo:index "1";
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -3626,8 +3909,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							)
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3647,8 +3928,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							}
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3716,8 +3995,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -3782,8 +4059,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 			#			}
 			#			FILTER (
 			#				?p != rdf:type
-			#				&& ?p != skos:prefLabel
-			#				&& ?p != skos:notation
 			#				&& ?p != bp4mc2:signature
 			#				&& ?p != dct:type
 			#				&& ?p != skos:member
@@ -3822,58 +4097,47 @@ stage:WeergaveVersiesConceptenQuery a elmo:Query;
 		SELECT DISTINCT (<@IDSUBJECT@> as ?concept) ?concept_label ?graph ?actueeltot
 		WHERE {
 			{
-				{
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						<@IDSUBJECT@> rdfs:isDefinedBy ?actualGraph.
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != ?actualGraph )
-					FILTER( substr("@GRAPH@",2) = "GRAPH@" )
-				}
-				UNION {
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != <@GRAPH@> )
-					FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
-				}
-				FILTER( contains( "@SUBJECT@", "@IDSUBJECT@" ) )
-			}
-			UNION
-			{
 				GRAPH ?graph {
 					<@IDSUBJECT@> rdf:type skos:Concept.
 					?graph prov:generatedAtTime ?concept_label.
-					?graph prov:generatedAtTime ?startTime.
 					OPTIONAL {
 						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
 					}
+				}
+				GRAPH ?actualGraph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?actualGraph prov:generatedAtTime ?startTime.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?endTime.
+					}
 					FILTER (
-						strdt( ?startTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
-						|| (
-							bound( ?actueeltot )
-							&& strdt( ?actueeltot, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						strdt( ?startTime, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						&& (
+							!bound( ?endTime )
+							|| strdt( ?endTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
 						)
 					)
 				}
 				GRAPH doc:mastergraph {
-					?graph dc:isVersionOf doc:mastergraph
+					?graph dc:isVersionOf doc:mastergraph.
+					?actualGraph dc:isVersionOf doc:mastergraph.
 				}
-				FILTER( !contains( "@SUBJECT@", "@IDSUBJECT@" ) )
+				FILTER( ?graph != ?actualGraph )
+				FILTER( substr("@GRAPH@",2) = "GRAPH@" )
+			}
+			UNION {
+				GRAPH ?graph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?graph prov:generatedAtTime ?concept_label.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
+					}
+				}
+				GRAPH doc:mastergraph {
+					?graph dc:isVersionOf doc:mastergraph
+				}	
+				FILTER( ?graph != <@GRAPH@> )
+				FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
 			}
 		}
 		ORDER BY DESC(lcase(?concept_label))
@@ -3928,31 +4192,36 @@ stage:WeergaveTabelWaardelijsten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4106,8 +4375,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4131,8 +4398,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4374,31 +4639,36 @@ stage:WeergaveTabelCollecties a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4548,8 +4818,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4567,8 +4835,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4832,6 +5098,11 @@ stage:WeergaveTabelCatalog a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5012,8 +5283,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5031,8 +5300,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5158,6 +5425,11 @@ stage:WeergaveTabelDataset a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5304,8 +5576,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5331,8 +5601,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5452,6 +5720,11 @@ stage:WeergaveTabelDistribution a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5576,8 +5849,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5595,8 +5866,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5761,6 +6030,11 @@ stage:WeergaveTabelActivity a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5803,6 +6077,11 @@ stage:WeergaveTabelAgent a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5875,8 +6154,6 @@ stage:WeergaveTabelActivityQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -5917,8 +6194,6 @@ stage:WeergaveTabelAgentQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -6083,46 +6358,51 @@ stage:WeergaveTabelShapes a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6282,8 +6562,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6300,8 +6578,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6352,8 +6628,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 						<@SUBJECT@> ?p ?o.
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member
@@ -6477,46 +6751,51 @@ stage:WeergaveTabelNormen a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6675,8 +6954,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6693,8 +6970,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6747,8 +7022,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 						}
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member

--- a/catalogusconfiguraties/dso/Stage DSO T.ttl
+++ b/catalogusconfiguraties/dso/Stage DSO T.ttl
@@ -621,18 +621,13 @@ stage:DSOCatalogusUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:catalogusupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:catalogusupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -835,6 +830,56 @@ container:excelupload a elmo:Container;
 	elmo:translator elmo:TableExcelTranslator;
 	rdfs:label "Upload concepten via Excel (.xls)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
 
@@ -846,8 +891,59 @@ container:ttlupload a elmo:Container;
 	elmo:representation elmo:UploadRepresentation;
 	rdfs:label "Upload concepten via RDF (.xml) of Turtle (.ttl)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
+
 # Updatecontainer Excel
 container:excelupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -857,8 +953,59 @@ container:excelupdate a elmo:Container;
     elmo:translator elmo:TableExcelTranslator;
     rdfs:label "Upload een enkel Concept via Excel (.xls)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
+
 # Updatecontainer Turtle
 container:ttlupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -867,6 +1014,56 @@ container:ttlupdate a elmo:Container;
     elmo:representation elmo:UploadRepresentation;
     rdfs:label "Upload een enkel Concept via RDF (.xml) of Turtle (.ttl)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -884,6 +1081,7 @@ container:concepten-put-xml a elmo:Container;
 			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.test.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-put-xml {
@@ -892,11 +1090,62 @@ container:concepten-put-xml a elmo:Container;
 				FILTER NOT EXISTS {
 					GRAPH doc:mastergraph {
 						?s rdf:type skos:Concept.
+						?s bp4mc2:signature ?sig.
 					}
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die nog niet bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -917,6 +1166,7 @@ container:concepten-post-xml a elmo:Container;
 			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
 			prefix doc: <http://data.test.pdok.nl/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-post-xml {
@@ -924,10 +1174,61 @@ container:concepten-post-xml a elmo:Container;
 				}
 				GRAPH doc:mastergraph {
 					?s rdf:type skos:Concept.
+					?s bp4mc2:signature ?sig.
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die al bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://data.test.pdok.nl/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -984,15 +1285,9 @@ stage:DSOGeneriekeUploadScene a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1292,15 +1587,9 @@ stage:DSOUploadScenePUT a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1544,24 +1833,13 @@ stage:DSODatasetUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:datasetupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:datasetupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
-				}
-				UNION {
-					?s dct:title ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -3091,51 +3369,56 @@ stage:WeergaveTabelConcepten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "00";
+	];
+	elmo:fragment [
 		rdfs:label "Notitie"@nl;
 		elmo:applies-to skos:notation;
-		elmo:index "1";
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -3626,8 +3909,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							)
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3647,8 +3928,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							}
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3716,8 +3995,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -3782,8 +4059,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 			#			}
 			#			FILTER (
 			#				?p != rdf:type
-			#				&& ?p != skos:prefLabel
-			#				&& ?p != skos:notation
 			#				&& ?p != bp4mc2:signature
 			#				&& ?p != dct:type
 			#				&& ?p != skos:member
@@ -3822,58 +4097,47 @@ stage:WeergaveVersiesConceptenQuery a elmo:Query;
 		SELECT DISTINCT (<@IDSUBJECT@> as ?concept) ?concept_label ?graph ?actueeltot
 		WHERE {
 			{
-				{
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						<@IDSUBJECT@> rdfs:isDefinedBy ?actualGraph.
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != ?actualGraph )
-					FILTER( substr("@GRAPH@",2) = "GRAPH@" )
-				}
-				UNION {
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != <@GRAPH@> )
-					FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
-				}
-				FILTER( contains( "@SUBJECT@", "@IDSUBJECT@" ) )
-			}
-			UNION
-			{
 				GRAPH ?graph {
 					<@IDSUBJECT@> rdf:type skos:Concept.
 					?graph prov:generatedAtTime ?concept_label.
-					?graph prov:generatedAtTime ?startTime.
 					OPTIONAL {
 						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
 					}
+				}
+				GRAPH ?actualGraph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?actualGraph prov:generatedAtTime ?startTime.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?endTime.
+					}
 					FILTER (
-						strdt( ?startTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
-						|| (
-							bound( ?actueeltot )
-							&& strdt( ?actueeltot, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						strdt( ?startTime, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						&& (
+							!bound( ?endTime )
+							|| strdt( ?endTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
 						)
 					)
 				}
 				GRAPH doc:mastergraph {
-					?graph dc:isVersionOf doc:mastergraph
+					?graph dc:isVersionOf doc:mastergraph.
+					?actualGraph dc:isVersionOf doc:mastergraph.
 				}
-				FILTER( !contains( "@SUBJECT@", "@IDSUBJECT@" ) )
+				FILTER( ?graph != ?actualGraph )
+				FILTER( substr("@GRAPH@",2) = "GRAPH@" )
+			}
+			UNION {
+				GRAPH ?graph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?graph prov:generatedAtTime ?concept_label.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
+					}
+				}
+				GRAPH doc:mastergraph {
+					?graph dc:isVersionOf doc:mastergraph
+				}	
+				FILTER( ?graph != <@GRAPH@> )
+				FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
 			}
 		}
 		ORDER BY DESC(lcase(?concept_label))
@@ -3928,31 +4192,36 @@ stage:WeergaveTabelWaardelijsten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4106,8 +4375,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4131,8 +4398,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4374,31 +4639,36 @@ stage:WeergaveTabelCollecties a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4548,8 +4818,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4567,8 +4835,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4832,6 +5098,11 @@ stage:WeergaveTabelCatalog a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5012,8 +5283,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5031,8 +5300,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5158,6 +5425,11 @@ stage:WeergaveTabelDataset a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5304,8 +5576,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5331,8 +5601,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5452,6 +5720,11 @@ stage:WeergaveTabelDistribution a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5576,8 +5849,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5595,8 +5866,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5761,6 +6030,11 @@ stage:WeergaveTabelActivity a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5803,6 +6077,11 @@ stage:WeergaveTabelAgent a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5875,8 +6154,6 @@ stage:WeergaveTabelActivityQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -5917,8 +6194,6 @@ stage:WeergaveTabelAgentQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -6083,46 +6358,51 @@ stage:WeergaveTabelShapes a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6282,8 +6562,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6300,8 +6578,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6352,8 +6628,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 						<@SUBJECT@> ?p ?o.
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member
@@ -6477,46 +6751,51 @@ stage:WeergaveTabelNormen a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6675,8 +6954,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6693,8 +6970,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6747,8 +7022,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 						}
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member

--- a/catalogusconfiguraties/dso/Stage DSO local.ttl
+++ b/catalogusconfiguraties/dso/Stage DSO local.ttl
@@ -621,18 +621,13 @@ stage:DSOCatalogusUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:catalogusupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:catalogusupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -835,6 +830,56 @@ container:excelupload a elmo:Container;
 	elmo:translator elmo:TableExcelTranslator;
 	rdfs:label "Upload concepten via Excel (.xls)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
 
@@ -846,8 +891,59 @@ container:ttlupload a elmo:Container;
 	elmo:representation elmo:UploadRepresentation;
 	rdfs:label "Upload concepten via RDF (.xml) of Turtle (.ttl)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
+
 # Updatecontainer Excel
 container:excelupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -857,8 +953,59 @@ container:excelupdate a elmo:Container;
     elmo:translator elmo:TableExcelTranslator;
     rdfs:label "Upload een enkel Concept via Excel (.xls)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
+
 # Updatecontainer Turtle
 container:ttlupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -867,6 +1014,56 @@ container:ttlupdate a elmo:Container;
     elmo:representation elmo:UploadRepresentation;
     rdfs:label "Upload een enkel Concept via RDF (.xml) of Turtle (.ttl)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -884,6 +1081,7 @@ container:concepten-put-xml a elmo:Container;
 			prefix container: <http://localhost:8080/catalogus/dso/container/>
 			prefix doc: <http://localhost:8080/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-put-xml {
@@ -892,11 +1090,62 @@ container:concepten-put-xml a elmo:Container;
 				FILTER NOT EXISTS {
 					GRAPH doc:mastergraph {
 						?s rdf:type skos:Concept.
+						?s bp4mc2:signature ?sig.
 					}
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die nog niet bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -917,6 +1166,7 @@ container:concepten-post-xml a elmo:Container;
 			prefix container: <http://localhost:8080/catalogus/dso/container/>
 			prefix doc: <http://localhost:8080/catalogus/dso/concepten/doc/>
 			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			prefix bp4mc2: <http://bp4mc2.org/elmo/def/>
 			
 			ASK {
 				GRAPH container:concepten-post-xml {
@@ -924,10 +1174,61 @@ container:concepten-post-xml a elmo:Container;
 				}
 				GRAPH doc:mastergraph {
 					?s rdf:type skos:Concept.
+					?s bp4mc2:signature ?sig.
 				}
 			}
 		''';
 		rdfs:label "De upload bevat concepten die al bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .
@@ -984,15 +1285,9 @@ stage:DSOGeneriekeUploadScene a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1292,15 +1587,9 @@ stage:DSOUploadScenePUT a elmo:Scene;
 			}
 		} WHERE {
 			GRAPH container:generiek {
-				{
-					{ ?s skos:prefLabel ?spreflabel. }
-					UNION { ?s dct:title ?spreflabel. }
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?spreflabel.
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -1544,24 +1833,13 @@ stage:DSODatasetUploadScene a elmo:Scene;
 		
 		INSERT {
 			GRAPH container:datasetupload {
-				?s rdfs:label ?slabel.
+				?s rdfs:label ?spreflabel.
 			}
 		} WHERE {
 			GRAPH container:datasetupload {
-				{
-					?s skos:prefLabel ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
-				}
-				UNION {
-					?s skosxl:prefLabel/skosxl:literalForm ?slabel.
-				}
-				UNION {
-					?s dct:title ?slabel.
-					FILTER NOT EXISTS {
-						?s rdfs:label ?slabel.
-					}
+				?s dct:title ?spreflabel.
+				FILTER NOT EXISTS {
+					?s rdfs:label ?slabel.
 				}
 			}
 		}
@@ -3091,51 +3369,56 @@ stage:WeergaveTabelConcepten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "00";
+	];
+	elmo:fragment [
 		rdfs:label "Notitie"@nl;
 		elmo:applies-to skos:notation;
-		elmo:index "1";
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -3626,8 +3909,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							)
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3647,8 +3928,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 							}
 							FILTER (
 								?p != rdf:type
-								&& ?p != skos:prefLabel
-								&& ?p != skos:notation
 								&& ?p != bp4mc2:signature
 								&& ?p != dct:type
 								&& ?p != skos:member
@@ -3716,8 +3995,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -3782,8 +4059,6 @@ stage:WeergaveTabelConceptenQuery a elmo:Query;
 			#			}
 			#			FILTER (
 			#				?p != rdf:type
-			#				&& ?p != skos:prefLabel
-			#				&& ?p != skos:notation
 			#				&& ?p != bp4mc2:signature
 			#				&& ?p != dct:type
 			#				&& ?p != skos:member
@@ -3822,58 +4097,47 @@ stage:WeergaveVersiesConceptenQuery a elmo:Query;
 		SELECT DISTINCT (<@IDSUBJECT@> as ?concept) ?concept_label ?graph ?actueeltot
 		WHERE {
 			{
-				{
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						<@IDSUBJECT@> rdfs:isDefinedBy ?actualGraph.
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != ?actualGraph )
-					FILTER( substr("@GRAPH@",2) = "GRAPH@" )
-				}
-				UNION {
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != <@GRAPH@> )
-					FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
-				}
-				FILTER( contains( "@SUBJECT@", "@IDSUBJECT@" ) )
-			}
-			UNION
-			{
 				GRAPH ?graph {
 					<@IDSUBJECT@> rdf:type skos:Concept.
 					?graph prov:generatedAtTime ?concept_label.
-					?graph prov:generatedAtTime ?startTime.
 					OPTIONAL {
 						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
 					}
+				}
+				GRAPH ?actualGraph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?actualGraph prov:generatedAtTime ?startTime.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?endTime.
+					}
 					FILTER (
-						strdt( ?startTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
-						|| (
-							bound( ?actueeltot )
-							&& strdt( ?actueeltot, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						strdt( ?startTime, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						&& (
+							!bound( ?endTime )
+							|| strdt( ?endTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
 						)
 					)
 				}
 				GRAPH doc:mastergraph {
-					?graph dc:isVersionOf doc:mastergraph
+					?graph dc:isVersionOf doc:mastergraph.
+					?actualGraph dc:isVersionOf doc:mastergraph.
 				}
-				FILTER( !contains( "@SUBJECT@", "@IDSUBJECT@" ) )
+				FILTER( ?graph != ?actualGraph )
+				FILTER( substr("@GRAPH@",2) = "GRAPH@" )
+			}
+			UNION {
+				GRAPH ?graph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?graph prov:generatedAtTime ?concept_label.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
+					}
+				}
+				GRAPH doc:mastergraph {
+					?graph dc:isVersionOf doc:mastergraph
+				}	
+				FILTER( ?graph != <@GRAPH@> )
+				FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
 			}
 		}
 		ORDER BY DESC(lcase(?concept_label))
@@ -3928,31 +4192,36 @@ stage:WeergaveTabelWaardelijsten a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4106,8 +4375,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4131,8 +4398,6 @@ stage:WeergaveTabelWaardelijstenQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4374,31 +4639,36 @@ stage:WeergaveTabelCollecties a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [
 		rdfs:label "Synoniemen"@nl;
@@ -4548,8 +4818,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4567,8 +4835,6 @@ stage:WeergaveTabelCollectiesQuery a elmo:Query;
 				}
 				FILTER (
 					?p != rdf:type
-					&& ?p != skos:prefLabel
-					&& ?p != skos:notation
 					&& ?p != bp4mc2:signature
 					&& ?p != dct:type
 					&& ?p != skos:member
@@ -4832,6 +5098,11 @@ stage:WeergaveTabelCatalog a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5012,8 +5283,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5031,8 +5300,6 @@ stage:WeergaveTabelCatalogQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5158,6 +5425,11 @@ stage:WeergaveTabelDataset a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5304,8 +5576,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5331,8 +5601,6 @@ stage:WeergaveTabelDatasetQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5452,6 +5720,11 @@ stage:WeergaveTabelDistribution a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5576,8 +5849,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5595,8 +5866,6 @@ stage:WeergaveTabelDistributionQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -5761,6 +6030,11 @@ stage:WeergaveTabelActivity a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
 		elmo:applies-to prov:generatedAtTime;
 		elmo:indx "13";
@@ -5803,6 +6077,11 @@ stage:WeergaveTabelAgent a elmo:Part;
 	elmo:fragment [
 		elmo:applies-to rdfs:label;
 		elmo:appearance elmo:HiddenAppearance
+	];
+	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
 	];
 	elmo:fragment [
 		rdfs:label "Startdatum versie"@nl;
@@ -5875,8 +6154,6 @@ stage:WeergaveTabelActivityQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -5917,8 +6194,6 @@ stage:WeergaveTabelAgentQuery a elmo:Query;
 			<@SUBJECT@> ?p ?o.
 			FILTER (
 				?p != rdf:type
-				&& ?p != skos:prefLabel
-				&& ?p != skos:notation
 				&& ?p != bp4mc2:signature
 				&& ?p != dct:type
 				&& ?p != skos:member
@@ -6083,46 +6358,51 @@ stage:WeergaveTabelShapes a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6282,8 +6562,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6300,8 +6578,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6352,8 +6628,6 @@ stage:WeergaveTabelShapesQuery a elmo:Query;
 						<@SUBJECT@> ?p ?o.
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member
@@ -6477,46 +6751,51 @@ stage:WeergaveTabelNormen a elmo:Part;
 		elmo:appearance elmo:HiddenAppearance
 	];
 	elmo:fragment [
+		rdfs:label "Naam"@nl;
+		elmo:applies-to skos:prefLabel;
+		elmo:index "01";
+	];
+	elmo:fragment [
 		rdfs:label "Uitleg"@nl;
 		elmo:applies-to skos:comment;
-		elmo:index "2";
+		elmo:index "02";
 	];
 	elmo:fragment [
 		rdfs:label "Definitie"@nl;
 		elmo:applies-to skos:definition;
-		elmo:index "3";
+		elmo:index "03";
 		elmo:appearance elmo:MarkdownAppearance;
 	];
 	elmo:fragment [
 		rdfs:label "Toelichting"@nl;
 		elmo:applies-to skos:scopeNote;
-		elmo:index "4";
+		elmo:index "04";
 	];
 	elmo:fragment [ 
 		rdfs:label "Bron"@nl;
 		elmo:applies-to dct:source;
 		elmo:appearance elmo:GlobalLink;
-		elmo:index "5";
+		elmo:index "05";
 	];
 	elmo:fragment [
 		rdfs:label "Domein"@nl;
 		elmo:applies-to skos:inScheme;
-		elmo:index "6";
+		elmo:index "06";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is specialisatie van"@nl;
 		elmo:applies-to thes:broaderGeneric;
-		elmo:index "7";
+		elmo:index "07";
 	];
 	elmo:fragment [
 		rdfs:label "Is generalisatie van"@nl;
 		elmo:applies-to thes:narrowerGeneric;
-		elmo:index "8";
+		elmo:index "08";
 	];
 	elmo:fragment [ 
 		rdfs:label "Is onderdeel van"@nl;
 		elmo:applies-to thes:broaderPartitive;
-		elmo:index "9";
+		elmo:index "09";
 	];
 	elmo:fragment [
 		rdfs:label "Bestaat uit"@nl;
@@ -6675,8 +6954,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6693,8 +6970,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 					}
 					FILTER (
 						?p != rdf:type
-						&& ?p != skos:prefLabel
-						&& ?p != skos:notation
 						&& ?p != bp4mc2:signature
 						&& ?p != dct:type
 						&& ?p != skos:member
@@ -6747,8 +7022,6 @@ stage:WeergaveTabelNormenQuery a elmo:Query;
 						}
 						FILTER (
 							?p != rdf:type
-							&& ?p != skos:prefLabel
-							&& ?p != skos:notation
 							&& ?p != bp4mc2:signature
 							&& ?p != dct:type
 							&& ?p != skos:member

--- a/catalogusconfiguraties/dso/onderdelen/03_Beheer_Concepten.ttl
+++ b/catalogusconfiguraties/dso/onderdelen/03_Beheer_Concepten.ttl
@@ -28,6 +28,56 @@ container:excelupload a elmo:Container;
 	elmo:translator elmo:TableExcelTranslator;
 	rdfs:label "Upload concepten via Excel (.xls)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
 
@@ -39,8 +89,59 @@ container:ttlupload a elmo:Container;
 	elmo:representation elmo:UploadRepresentation;
 	rdfs:label "Upload concepten via RDF (.xml) of Turtle (.ttl)";
 	elmo:replaces container:generiek;
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupload {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
 	elmo:query stage:DSOGeneriekeUploadScene;
 .
+
 # Updatecontainer Excel
 container:excelupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -50,8 +151,59 @@ container:excelupdate a elmo:Container;
     elmo:translator elmo:TableExcelTranslator;
     rdfs:label "Upload een enkel Concept via Excel (.xls)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:excelupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
+
 # Updatecontainer Turtle
 container:ttlupdate a elmo:Container;
     elmo:contains stage:DSOBeheermenu;
@@ -60,6 +212,56 @@ container:ttlupdate a elmo:Container;
     elmo:representation elmo:UploadRepresentation;
     rdfs:label "Upload een enkel Concept via RDF (.xml) of Turtle (.ttl)";
     elmo:replaces container:generiek;
+		elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:ttlupdate {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -93,6 +295,56 @@ container:concepten-put-xml a elmo:Container;
 		''';
 		rdfs:label "De upload bevat concepten die nog niet bestaan.";
 	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-put-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
+	];
     elmo:query stage:DSOUploadScenePUT;
 .
 
@@ -125,6 +377,56 @@ container:concepten-post-xml a elmo:Container;
 			}
 		''';
 		rdfs:label "De upload bevat concepten die al bestaan.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s rdfs:label ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder rdfs:label bevatten.";
+	];
+	elmo:assertion [
+		elmo:assert-not '''
+			prefix container: <http://localhost:8080/catalogus/dso/container/>
+			prefix skos: <http://www.w3.org/2004/02/skos/core#>
+			
+			ASK {
+				GRAPH container:concepten-post-xml {
+					{
+						?s rdf:type skos:Concept.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+					UNION
+					{
+						?s rdf:type skos:Collection.
+						FILTER NOT EXISTS {
+							?s skos:prefLabel ?label.
+						}
+					}
+				}
+			}
+		''';
+		rdfs:label "De upload mag geen concepten of collecties zonder skos:prefLabel bevatten.";
 	];
     elmo:query stage:DSOUploadScenePUT;
 .

--- a/catalogusconfiguraties/dso/onderdelen/11_Weergave_Concepten.ttl
+++ b/catalogusconfiguraties/dso/onderdelen/11_Weergave_Concepten.ttl
@@ -757,58 +757,47 @@ stage:WeergaveVersiesConceptenQuery a elmo:Query;
 		SELECT DISTINCT (<@IDSUBJECT@> as ?concept) ?concept_label ?graph ?actueeltot
 		WHERE {
 			{
-				{
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						<@IDSUBJECT@> rdfs:isDefinedBy ?actualGraph.
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != ?actualGraph )
-					FILTER( substr("@GRAPH@",2) = "GRAPH@" )
-				}
-				UNION {
-					GRAPH ?graph {
-						<@IDSUBJECT@> rdf:type skos:Concept.
-						?graph prov:generatedAtTime ?concept_label.
-						OPTIONAL {
-							<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
-						}
-					}
-					GRAPH doc:mastergraph {
-						?graph dc:isVersionOf doc:mastergraph
-					}	
-					FILTER( ?graph != <@GRAPH@> )
-					FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
-				}
-				FILTER( contains( "@SUBJECT@", "@IDSUBJECT@" ) )
-			}
-			UNION
-			{
 				GRAPH ?graph {
 					<@IDSUBJECT@> rdf:type skos:Concept.
 					?graph prov:generatedAtTime ?concept_label.
-					?graph prov:generatedAtTime ?startTime.
 					OPTIONAL {
 						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
 					}
+				}
+				GRAPH ?actualGraph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?actualGraph prov:generatedAtTime ?startTime.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?endTime.
+					}
 					FILTER (
-						strdt( ?startTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
-						|| (
-							bound( ?actueeltot )
-							&& strdt( ?actueeltot, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						strdt( ?startTime, xsd:dateTime ) <= "@TIMESTAMP@"^^xsd:dateTime
+						&& (
+							!bound( ?endTime )
+							|| strdt( ?endTime, xsd:dateTime ) > "@TIMESTAMP@"^^xsd:dateTime
 						)
 					)
 				}
 				GRAPH doc:mastergraph {
-					?graph dc:isVersionOf doc:mastergraph
+					?graph dc:isVersionOf doc:mastergraph.
+					?actualGraph dc:isVersionOf doc:mastergraph.
 				}
-				FILTER( !contains( "@SUBJECT@", "@IDSUBJECT@" ) )
+				FILTER( ?graph != ?actualGraph )
+				FILTER( substr("@GRAPH@",2) = "GRAPH@" )
+			}
+			UNION {
+				GRAPH ?graph {
+					<@IDSUBJECT@> rdf:type skos:Concept.
+					?graph prov:generatedAtTime ?concept_label.
+					OPTIONAL {
+						<@IDSUBJECT@> prov:invalidatedAtTime ?actueeltot.
+					}
+				}
+				GRAPH doc:mastergraph {
+					?graph dc:isVersionOf doc:mastergraph
+				}	
+				FILTER( ?graph != <@GRAPH@> )
+				FILTER ( substr("@GRAPH@",2) != "GRAPH@" )
 			}
 		}
 		ORDER BY DESC(lcase(?concept_label))

--- a/catalogusdata/Concepten/Concepten DSO A.ttl
+++ b/catalogusdata/Concepten/Concepten DSO A.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix dso: <http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/>.
 @prefix collection: <http://data.acceptatie.pdok.nl/catalogus/dso/id/collection/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.

--- a/catalogusdata/Concepten/Concepten DSO O.ttl
+++ b/catalogusdata/Concepten/Concepten DSO O.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix dso: <http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/>.
 @prefix collection: <http://data.ontwikkeling.pdok.nl/catalogus/dso/id/collection/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.

--- a/catalogusdata/Concepten/Concepten DSO T.ttl
+++ b/catalogusdata/Concepten/Concepten DSO T.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix dso: <http://data.test.pdok.nl/catalogus/dso/id/concept/>.
 @prefix collection: <http://data.test.pdok.nl/catalogus/dso/id/collection/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.

--- a/catalogusdata/Concepten/Testdata concepten O.ttl
+++ b/catalogusdata/Concepten/Testdata concepten O.ttl
@@ -1,5 +1,5 @@
-﻿@prefix concept:		<http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/>.
-@prefix collection:		<http://data.ontwikkeling.pdok.nl/catalogus/dso/id/collection/>.
+@prefix concept:		<http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/>.
+@prefix collection:		<http://data.acceptatie.pdok.nl/catalogus/dso/id/collection/>.
 @prefix rdf: 			<http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: 			<http://www.w3.org/2000/01/rdf-schema#>.
 @prefix skos: 			<http://www.w3.org/2004/02/skos/core#>.
@@ -11,8 +11,9 @@
 
 # Concepten
 concept:GeneriekeSchildpad a skos:Concept;
-	skos:prefLabel "Generieke schildpad";
-	skos:definition "Een schildpad zo generiek dat het zijn gelijke niet kent.";
+	skos:prefLabel "GeneriekeSchildpad";
+	rdfs:label "Generieke schildpad";
+	skos:definition "Een schildpad zo generiek dat het zijn gelijke niet kent";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Generieke tortoise";
 	dct:source concept:Art1_2Lid1Awb;
@@ -22,7 +23,8 @@ concept:GeneriekeSchildpad a skos:Concept;
 .
 
 concept:SpecifiekeSchildpad a skos:Concept;
-	skos:prefLabel "Specifieke schildpad";
+	skos:prefLabel "SpecifiekeSchildpad";
+	rdfs:label "Specifieke schildpad";
 	skos:definition "Een iets minder generieke, dan wel specifiekere schildpad";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Specifieke tortoise";
@@ -33,6 +35,7 @@ concept:SpecifiekeSchildpad a skos:Concept;
 
 concept:Kop a skos:Concept;
 	skos:prefLabel "Kop";
+	rdfs:label "Kop";
 	skos:definition "Deel van een schildpad, om precies te zijn de kop";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -42,6 +45,7 @@ concept:Kop a skos:Concept;
 
 concept:Lijf a skos:Concept;
 	skos:prefLabel "Lijf";
+	rdfs:label "Lijf";
 	skos:definition "Deel van een schildpad, om precies te zijn het lijf";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -51,6 +55,7 @@ concept:Lijf a skos:Concept;
 
 concept:Poten a skos:Concept;
 	skos:prefLabel "Poten";
+	rdfs:label "Poten";
 	skos:definition "Deel van een schildpad, om precies te zijn de poten";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -59,7 +64,8 @@ concept:Poten a skos:Concept;
 .
 
 concept:AndereSchildpad a skos:Concept;
-	skos:prefLabel "Andere schildpad";
+	skos:prefLabel "AndereSchildpad";
+	rdfs:label "Andere schildpad";
 	skos:definition "Een andere schildpad";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Andere tortoise";
@@ -69,7 +75,8 @@ concept:AndereSchildpad a skos:Concept;
 .
 
 concept:AndereSpecifiekeSchildpad a skos:Concept;
-	skos:prefLabel "Andere specifieke schildpad";
+	skos:prefLabel "AndereSpecifiekeSchildpad";
+	rdfs:label "Andere specifieke schildpad";
 	skos:definition "Een andere specifieke schildpad";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -77,7 +84,8 @@ concept:AndereSpecifiekeSchildpad a skos:Concept;
 .
 
 concept:SingleSchildpad a skos:Concept;
-	skos:prefLabel "Single schildpad";
+	skos:prefLabel "SingleSchildpad";
+	rdfs:label "Single schildpad";
 	skos:definition "Een schildpad zonder relaties";
 	skos:inScheme concept:schildpadDomein;
 	dct:valid "1-1-2001";
@@ -85,88 +93,103 @@ concept:SingleSchildpad a skos:Concept;
 
 # Activiteiten
 concept:GeneriekeActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Generieke activiteit";
+	skos:prefLabel "GeneriekeActiviteit";
+	rdfs:label "Generieke activiteit";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekeActiviteit
 .
 
 concept:SpecifiekeActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Specifieke activiteit";
+	skos:prefLabel "SpecifiekeActiviteit";
+	rdfs:label "Specifieke activiteit";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekereActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Nog specifiekere activiteit";
+	skos:prefLabel "NogSpecifiekereActiviteit";
+	rdfs:label "Nog specifiekere activiteit";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekeActiviteit
 .
 
 concept:SingleActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Single activiteit";
+	skos:prefLabel "SingleActiviteit";
+	rdfs:label "Single activiteit";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Normen
 concept:GeneriekeNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Generieke norm";
+	skos:prefLabel "GeneriekeNorm";
+	rdfs:label "Generieke norm";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekeNorm
 .
 
 concept:SpecifiekeNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Specifieke norm";
+	skos:prefLabel "SpecifiekeNorm";
+	rdfs:label "Specifieke norm";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekereNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Nog specifiekere norm";
+	skos:prefLabel "NogSpecifiekereNorm";
+	rdfs:label "Nog specifiekere norm";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekeNorm
 .
 
 concept:SingleNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Single norm";
+	skos:prefLabel "SingleNorm";
+	rdfs:label "Single norm";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Objecten
 concept:GeneriekObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Generiekobject";
+	skos:prefLabel "GeneriekObject";
+	rdfs:label "Generiek object";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekObject
 .
 
 concept:SpecifiekObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Specifiekobject";
+	skos:prefLabel "SpecifiekObject";
+	rdfs:label "Specifiek object";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekerObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Nog specifiekerobject";
+	skos:prefLabel "Nog specifiekerObject";
+	rdfs:label "Nog specifieker object";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekObject
 .
 
 concept:SinglObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Singlobject";
+	skos:prefLabel "SingleObject";
+	rdfs:label "Single object";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Collecties
 collection:StandaardSchildpadden a skos:Collection;
-	rdfs:label "Standaardschildpadden";
+	rdfs:label "Standaard schildpadden";
+	skos:prefLabel "StandaardSchildpadden";
 	skos:member concept:GeneriekeSchildpad;
 	skos:member concept:SpecifiekeSchildpad;
 .
 
 collection:AndereSchildpadden a skos:Collection;
 	rdfs:label "Andere schildpadden";
+	skos:prefLabel "AndereSchildpadden";
 	skos:member concept:AndereSchildpad;
 	skos:member concept:AndereSpecifiekeSchildpad;
 .
 
 collection:Activiteiten a skos:Collection;
 	rdfs:label "Activiteiten";
+	skos:prefLabel "Activiteiten";
 	skos:member concept:GeneriekeActiviteit;
 	skos:member concept:SpecifiekeActiviteit;
 	skos:member concept:NogSpecifiekereActiviteit;
@@ -175,6 +198,7 @@ collection:Activiteiten a skos:Collection;
 
 collection:Normen a skos:Collection;
 	rdfs:label "Normen";
+	skos:prefLabel "Normen";
 	skos:member concept:GeneriekeNorm;
 	skos:member concept:SpecifiekeNorm;
 	skos:member concept:NogSpecifiekereNorm;
@@ -183,6 +207,7 @@ collection:Normen a skos:Collection;
 
 collection:Objecten a skos:Collection;
 	rdfs:label "Objecten";
+	skos:prefLabel "Objecten";
 	skos:member concept:GeneriekObject;
 	skos:member concept:SpecifiekObject;
 	skos:member concept:NogSpecifiekerObject;
@@ -192,11 +217,13 @@ collection:Objecten a skos:Collection;
 # Waardelijsten
 collection:Waardelijsten a skos:Collection;
 	rdfs:label "Waardelijsten";
+	skos:prefLabel "Waardelijsten";
 	skos:member collection:Lichaamsdelen;
 .
 
 collection:Lichaamsdelen a skos:Collection;
 	rdfs:label "Lichaamsdelen";
+	skos:prefLabel "Lichaamsdelen";
 	skos:member concept:Kop;
 	skos:member concept:Lijf;
 	skos:member concept:Poten;
@@ -205,12 +232,14 @@ collection:Lichaamsdelen a skos:Collection;
 # Toeleidingsbegrippen
 collection:Toeleidingsbegrippen a skos:Collection;
 	rdfs:label "Toeleidingsbegrippen";
+	skos:prefLabel "Toeleidingsbegrippen";
 	skos:member concept:Zeedier;
 .
 
 concept:Zeedier a skos:Concept;
 	skos:closeMatch concept:GeneriekeSchildpad;
 	rdfs:label "Zeedier";
+	skos:prefLabel "Zeedier";
 .
 
 # Bronnen

--- a/catalogusdata/Concepten/Testdata concepten local.ttl
+++ b/catalogusdata/Concepten/Testdata concepten local.ttl
@@ -11,7 +11,8 @@
 
 # Concepten
 concept:GeneriekeSchildpad a skos:Concept;
-	skos:prefLabel "Generieke schildpad";
+	skos:prefLabel "GeneriekeSchildpad";
+	rdfs:label "Generieke schildpad";
 	skos:definition "Een schildpad zo generiek dat het zijn gelijke niet kent";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Generieke tortoise";
@@ -22,7 +23,8 @@ concept:GeneriekeSchildpad a skos:Concept;
 .
 
 concept:SpecifiekeSchildpad a skos:Concept;
-	skos:prefLabel "Specifieke schildpad";
+	skos:prefLabel "SpecifiekeSchildpad";
+	rdfs:label "Specifieke schildpad";
 	skos:definition "Een iets minder generieke, dan wel specifiekere schildpad";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Specifieke tortoise";
@@ -33,6 +35,7 @@ concept:SpecifiekeSchildpad a skos:Concept;
 
 concept:Kop a skos:Concept;
 	skos:prefLabel "Kop";
+	rdfs:label "Kop";
 	skos:definition "Deel van een schildpad, om precies te zijn de kop";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -42,6 +45,7 @@ concept:Kop a skos:Concept;
 
 concept:Lijf a skos:Concept;
 	skos:prefLabel "Lijf";
+	rdfs:label "Lijf";
 	skos:definition "Deel van een schildpad, om precies te zijn het lijf";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -51,6 +55,7 @@ concept:Lijf a skos:Concept;
 
 concept:Poten a skos:Concept;
 	skos:prefLabel "Poten";
+	rdfs:label "Poten";
 	skos:definition "Deel van een schildpad, om precies te zijn de poten";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -59,7 +64,8 @@ concept:Poten a skos:Concept;
 .
 
 concept:AndereSchildpad a skos:Concept;
-	skos:prefLabel "Andere schildpad";
+	skos:prefLabel "AndereSchildpad";
+	rdfs:label "Andere schildpad";
 	skos:definition "Een andere schildpad";
 	skos:inScheme concept:schildpadDomein;
 	skos:altLabel "Andere tortoise";
@@ -69,7 +75,8 @@ concept:AndereSchildpad a skos:Concept;
 .
 
 concept:AndereSpecifiekeSchildpad a skos:Concept;
-	skos:prefLabel "Andere specifieke schildpad";
+	skos:prefLabel "AndereSpecifiekeSchildpad";
+	rdfs:label "Andere specifieke schildpad";
 	skos:definition "Een andere specifieke schildpad";
 	skos:inScheme concept:schildpadDomein;
 	dct:source concept:Art1_3Lid2Awb;
@@ -77,7 +84,8 @@ concept:AndereSpecifiekeSchildpad a skos:Concept;
 .
 
 concept:SingleSchildpad a skos:Concept;
-	skos:prefLabel "Single schildpad";
+	skos:prefLabel "SingleSchildpad";
+	rdfs:label "Single schildpad";
 	skos:definition "Een schildpad zonder relaties";
 	skos:inScheme concept:schildpadDomein;
 	dct:valid "1-1-2001";
@@ -85,88 +93,103 @@ concept:SingleSchildpad a skos:Concept;
 
 # Activiteiten
 concept:GeneriekeActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Generieke activiteit";
+	skos:prefLabel "GeneriekeActiviteit";
+	rdfs:label "Generieke activiteit";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekeActiviteit
 .
 
 concept:SpecifiekeActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Specifieke activiteit";
+	skos:prefLabel "SpecifiekeActiviteit";
+	rdfs:label "Specifieke activiteit";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekereActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Nog specifiekere activiteit";
+	skos:prefLabel "NogSpecifiekereActiviteit";
+	rdfs:label "Nog specifiekere activiteit";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekeActiviteit
 .
 
 concept:SingleActiviteit a skos:Concept, skoslex:Act;
-	skos:prefLabel "Single activiteit";
+	skos:prefLabel "SingleActiviteit";
+	rdfs:label "Single activiteit";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Normen
 concept:GeneriekeNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Generieke norm";
+	skos:prefLabel "GeneriekeNorm";
+	rdfs:label "Generieke norm";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekeNorm
 .
 
 concept:SpecifiekeNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Specifieke norm";
+	skos:prefLabel "SpecifiekeNorm";
+	rdfs:label "Specifieke norm";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekereNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Nog specifiekere norm";
+	skos:prefLabel "NogSpecifiekereNorm";
+	rdfs:label "Nog specifiekere norm";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekeNorm
 .
 
 concept:SingleNorm a skos:Concept, skoslex:Norm;
-	skos:prefLabel "Single norm";
+	skos:prefLabel "SingleNorm";
+	rdfs:label "Single norm";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Objecten
 concept:GeneriekObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Generiekobject";
+	skos:prefLabel "GeneriekObject";
+	rdfs:label "Generiek object";
 	skos:inScheme concept:schildpadDomein;
 	thes:narrowerGeneric concept:SpecifiekObject
 .
 
 concept:SpecifiekObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Specifiekobject";
+	skos:prefLabel "SpecifiekObject";
+	rdfs:label "Specifiek object";
 	skos:inScheme concept:schildpadDomein;
 .
 
 concept:NogSpecifiekerObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Nog specifiekerobject";
+	skos:prefLabel "Nog specifiekerObject";
+	rdfs:label "Nog specifieker object";
 	skos:inScheme concept:schildpadDomein;
 	thes:broaderGeneric concept:SpecifiekObject
 .
 
 concept:SinglObject a skos:Concept, skoslex:Object;
-	skos:prefLabel "Singlobject";
+	skos:prefLabel "SingleObject";
+	rdfs:label "Single object";
 	skos:inScheme concept:schildpadDomein
 .
 
 # Collecties
 collection:StandaardSchildpadden a skos:Collection;
-	rdfs:label "Standaardschildpadden";
+	rdfs:label "Standaard schildpadden";
+	skos:prefLabel "StandaardSchildpadden";
 	skos:member concept:GeneriekeSchildpad;
 	skos:member concept:SpecifiekeSchildpad;
 .
 
 collection:AndereSchildpadden a skos:Collection;
 	rdfs:label "Andere schildpadden";
+	skos:prefLabel "AndereSchildpadden";
 	skos:member concept:AndereSchildpad;
 	skos:member concept:AndereSpecifiekeSchildpad;
 .
 
 collection:Activiteiten a skos:Collection;
 	rdfs:label "Activiteiten";
+	skos:prefLabel "Activiteiten";
 	skos:member concept:GeneriekeActiviteit;
 	skos:member concept:SpecifiekeActiviteit;
 	skos:member concept:NogSpecifiekereActiviteit;
@@ -175,6 +198,7 @@ collection:Activiteiten a skos:Collection;
 
 collection:Normen a skos:Collection;
 	rdfs:label "Normen";
+	skos:prefLabel "Normen";
 	skos:member concept:GeneriekeNorm;
 	skos:member concept:SpecifiekeNorm;
 	skos:member concept:NogSpecifiekereNorm;
@@ -183,6 +207,7 @@ collection:Normen a skos:Collection;
 
 collection:Objecten a skos:Collection;
 	rdfs:label "Objecten";
+	skos:prefLabel "Objecten";
 	skos:member concept:GeneriekObject;
 	skos:member concept:SpecifiekObject;
 	skos:member concept:NogSpecifiekerObject;
@@ -192,11 +217,13 @@ collection:Objecten a skos:Collection;
 # Waardelijsten
 collection:Waardelijsten a skos:Collection;
 	rdfs:label "Waardelijsten";
+	skos:prefLabel "Waardelijsten";
 	skos:member collection:Lichaamsdelen;
 .
 
 collection:Lichaamsdelen a skos:Collection;
 	rdfs:label "Lichaamsdelen";
+	skos:prefLabel "Lichaamsdelen";
 	skos:member concept:Kop;
 	skos:member concept:Lijf;
 	skos:member concept:Poten;
@@ -205,12 +232,14 @@ collection:Lichaamsdelen a skos:Collection;
 # Toeleidingsbegrippen
 collection:Toeleidingsbegrippen a skos:Collection;
 	rdfs:label "Toeleidingsbegrippen";
+	skos:prefLabel "Toeleidingsbegrippen";
 	skos:member concept:Zeedier;
 .
 
 concept:Zeedier a skos:Concept;
 	skos:closeMatch concept:GeneriekeSchildpad;
 	rdfs:label "Zeedier";
+	skos:prefLabel "Zeedier";
 .
 
 # Bronnen

--- a/catalogusdata/IHR/beg_ro.data.informatiehuisruimte.nl.bestemmingsplan.ttl
+++ b/catalogusdata/IHR/beg_ro.data.informatiehuisruimte.nl.bestemmingsplan.ttl
@@ -1,6 +1,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skos-thes: <http://purl.org/iso25964/skos-thes#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dctypes: <http://purl.org/dc/dcmitype/> .
 @prefix ro_col: <http://data.informatiehuisruimte.nl/id/collectie/> .
@@ -29,7 +30,7 @@ ro_nen3610_beg:GeoObject a skos:Concept ;
 ro_nen3610_beg:PlanologischGebied a skos:Concept ;
   rdfs:label "Planologisch gebied"@nl ;
   skos:prefLabel "Planologisch gebied"@nl ;
-  skos:broader ro_nen3610_beg:GeoObject ;
+  skos-thes:broaderGeneric ro_nen3610_beg:GeoObject ;
   skos:inScheme ro_begkr:ro ;
   skos:definition "Niet-tastbaar begrensd gebied waaraan een bepaalde (toekomstige) bestemming, functionele en/of bestuurlijke ruimtelijke ontwikkeling is gekoppeld."@nl ;
   skos:scopeNote "Planologische gebieden vormen de geo-objecten die worden gebruikt om het beleid van de ruimtelijke ordening weer te geven. In de regel zijn het objecten die zijn gekoppeld aan beleidsinformatie die aangeeft wat waar krachtens de wet op de ruimtelijke ordening aan beleid is geformuleerd."@nl ;
@@ -42,7 +43,7 @@ ro_nen3610_beg:PlanologischGebied a skos:Concept ;
 ro_beg:Plangebied a skos:Concept ;
   rdfs:label "Plangebied"@nl ;
   skos:prefLabel "Plangebied"@nl ;
-  skos:broader ro_nen3610_beg:PLanologischGebied ;
+  skos-thes:broaderGeneric ro_nen3610_beg:PlanologischGebied ;
   skos:inScheme ro_begkr:ro ;
   skos:definition "Het object dat het gebied, of de gebieden, binnen de plangrenzen representeert."@nl ;
   skos:scopeNote "Omvat het totale gebied van een benoemd ruimtelijk instrument. Bijvoorbeeld een bestemmingsplan, een structuurvisie een gebiedsgericht besluit."@nl ;
@@ -55,7 +56,7 @@ ro_beg:Plangebied a skos:Concept ;
 ro_beg:Planobject a skos:Concept ;
   rdfs:label "Planobject"@nl ;
   skos:prefLabel "Planobject"@nl ;
-  skos:broader ro_nen3610_beg:PLanologischGebied ;
+  skos-thes:broaderPartitive ro_nen3610_beg:PlanologischGebied ;
   skos:inScheme ro_begkr:ro ;
   skos:definition "Objecten waar een plangebied uit samengesteld is."@nl ;
   skos:scopeNote "Dit zijn de planobjecten waar een benoemd instrument uit de klasse Plangebied uit opgebouwd is. Bijvoorbeeld een object Bestemmingsvlak een object Aanduiding, Besluitvlak etc. Het zijn de ruimtelijke objecten waar de planinformatie aan gekoppeld is."@nl ;
@@ -66,7 +67,7 @@ ro_beg:Planobject a skos:Concept ;
 ro_beg:Bestemmingsplangebied a skos:Concept ;
   rdfs:label "Bestemmingsplangebied"@nl ;
   skos:prefLabel "Bestemmingsplangebied"@nl ;
-  skos:broader ro_beg:Plangebied ;
+  skos-thes:broaderGeneric ro_beg:Plangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:definition "Gebied, of de gebieden, binnen de grenzen van het bestemmingsplan."@nl ;
   skos:scopeNote "Het object (de klasse) Bestemmingsplangebied is het object dat het gebied, of de gebieden, binnen de plangrenzen geometrisch representeert. Aan dit object worden de algemene eigenschappen van het plangebied als attribuut gekoppeld."@nl ;
@@ -77,7 +78,7 @@ ro_beg:Bestemmingsplangebied a skos:Concept ;
 ro_beg:Bestemmingsplan a skos:Concept ;
   rdfs:label "Bestemmingsplan"@nl ;
   skos:prefLabel "Bestemmingsplan"@nl ;
-  skos:broader ro_beg:Bestemmingsplangebied ;
+  skos-thes:broaderGeneric ro_beg:Bestemmingsplangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "bestemmingsplan"
 .
@@ -85,7 +86,7 @@ ro_beg:Bestemmingsplan a skos:Concept ;
 ro_beg:Inpassingsplan a skos:Concept ;
   rdfs:label "Inpassingsplan"@nl ;
   skos:prefLabel "Inpassingsplan"@nl ;
-  skos:broader ro_beg:Bestemmingsplangebied ;
+  skos-thes:broaderGeneric ro_beg:Bestemmingsplangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "inpassingsplan"
 .
@@ -93,7 +94,7 @@ ro_beg:Inpassingsplan a skos:Concept ;
 ro_beg:Rijksbestemmingsplan a skos:Concept ;
   rdfs:label "Rijksbestemmingsplan"@nl ;
   skos:prefLabel "Rijksbestemmingsplan"@nl ;
-  skos:broader ro_beg:Bestemmingsplangebied ;
+  skos-thes:broaderGeneric ro_beg:Bestemmingsplangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "rijksbestemmingsplan"
 .
@@ -101,7 +102,7 @@ ro_beg:Rijksbestemmingsplan a skos:Concept ;
 ro_beg:Uitwerkingsplan a skos:Concept ;
   rdfs:label "Uitwerkingsplan"@nl ;
   skos:prefLabel "Uitwerkingsplan"@nl ;
-  skos:broader ro_beg:Bestemmingsplangebied ;
+  skos-thes:broaderGeneric ro_beg:Bestemmingsplangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "uitwerkingsplan"
 .
@@ -109,7 +110,7 @@ ro_beg:Uitwerkingsplan a skos:Concept ;
 ro_beg:Wijzigingsplan a skos:Concept ;
   rdfs:label "Wijzigingsplan"@nl ;
   skos:prefLabel "Wijzigingsplan"@nl ;
-  skos:broader ro_beg:Bestemmingsplangebied ;
+  skos-thes:broaderGeneric ro_beg:Bestemmingsplangebied ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "wijzigingsplan"
 .
@@ -124,7 +125,7 @@ ro_beg:externPlan a skos:Concept ;
 ro_beg:muteert a skos:Concept ;
   rdfs:label "muteert"@nl ;
   skos:prefLabel "muteert"@nl ;
-  skos:broader ro_beg:externPlan ;
+  skos-thes:broaderGeneric ro_beg:externPlan ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "als mutatie opgenomen"
 .
@@ -132,7 +133,7 @@ ro_beg:muteert a skos:Concept ;
 ro_beg:vervangt a skos:Concept ;
   rdfs:label "vervangt"@nl ;
   skos:prefLabel "vervangt"@nl ;
-  skos:broader ro_beg:externPlan ;
+  skos-thes:broaderGeneric ro_beg:externPlan ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "ter vervanging van extern plan"
 .
@@ -140,7 +141,7 @@ ro_beg:vervangt a skos:Concept ;
 ro_beg:tenGevolgeVan a skos:Concept ;
   rdfs:label "ten gevolge van"@nl ;
   skos:prefLabel "ten gevolge van"@nl ;
-  skos:broader ro_beg:externPlan ;
+  skos-thes:broaderGeneric ro_beg:externPlan ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "ten gevolge van extern plan/besluit"
 .
@@ -164,7 +165,7 @@ ro_beg:Omvang a skos:Concept ;
 ro_beg:Aantal_Omvang a skos:Concept ;
   rdfs:label "Aantal (Omvang)"@nl ;
   skos:prefLabel "Aantal (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -173,7 +174,7 @@ ro_beg:Aantal_Omvang a skos:Concept ;
 ro_beg:AantalBedrijven_Omvang a skos:Concept ;
   rdfs:label "Aantal bedrijven (Omvang)"@nl ;
   skos:prefLabel "Aantal bedrijven (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal bedrijven" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -182,7 +183,7 @@ ro_beg:AantalBedrijven_Omvang a skos:Concept ;
 ro_beg:MaximumAantalBedrijven_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal bedrijven (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal bedrijven (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal bedrijven" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -191,7 +192,7 @@ ro_beg:MaximumAantalBedrijven_Omvang a skos:Concept ;
 ro_beg:MinimumAantalBedrijven_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal bedrijven (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal bedrijven (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal bedrijven" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -200,7 +201,7 @@ ro_beg:MinimumAantalBedrijven_Omvang a skos:Concept ;
 ro_beg:AantalBezoekers_Omvang a skos:Concept ;
   rdfs:label "Aantal bezoekers (Omvang)"@nl ;
   skos:prefLabel "Aantal bezoekers (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal bezoekers" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -209,7 +210,7 @@ ro_beg:AantalBezoekers_Omvang a skos:Concept ;
 ro_beg:MaximumAantalBezoekers_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal bezoekers (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal bezoekers (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal bezoekers" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -218,7 +219,7 @@ ro_beg:MaximumAantalBezoekers_Omvang a skos:Concept ;
 ro_beg:MinimumAantalBezoekers_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal bezoekers (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal bezoekers (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal bezoekers" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -227,7 +228,7 @@ ro_beg:MinimumAantalBezoekers_Omvang a skos:Concept ;
 ro_beg:AantalBouwlagen_Omvang a skos:Concept ;
   rdfs:label "Aantal bouwlagen (Omvang)"@nl ;
   skos:prefLabel "Aantal bouwlagen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal bouwlagen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -236,7 +237,7 @@ ro_beg:AantalBouwlagen_Omvang a skos:Concept ;
 ro_beg:MaximumAantalBouwlagen_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal bouwlagen (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal bouwlagen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal bouwlagen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -245,7 +246,7 @@ ro_beg:MaximumAantalBouwlagen_Omvang a skos:Concept ;
 ro_beg:MinimumAantalBouwlagen_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal bouwlagen (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal bouwlagen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal bouwlagen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -254,7 +255,7 @@ ro_beg:MinimumAantalBouwlagen_Omvang a skos:Concept ;
 ro_beg:AantalGebouwen_Omvang a skos:Concept ;
   rdfs:label "Aantal gebouwen (Omvang)"@nl ;
   skos:prefLabel "Aantal gebouwen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal gebouwen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -263,7 +264,7 @@ ro_beg:AantalGebouwen_Omvang a skos:Concept ;
 ro_beg:MaximumAantalGebouwen_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal gebouwen (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal gebouwen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal gebouwen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -272,7 +273,7 @@ ro_beg:MaximumAantalGebouwen_Omvang a skos:Concept ;
 ro_beg:MinimumAantalGebouwen_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal gebouwen (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal gebouwen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal gebouwen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -281,7 +282,7 @@ ro_beg:MinimumAantalGebouwen_Omvang a skos:Concept ;
 ro_beg:AantalParkeerplaatsen_Omvang a skos:Concept ;
   rdfs:label "Aantal parkeerplaatsen (Omvang)"@nl ;
   skos:prefLabel "Aantal parkeerplaatsen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal parkeerplaatsen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -290,7 +291,7 @@ ro_beg:AantalParkeerplaatsen_Omvang a skos:Concept ;
 ro_beg:MaximumAantalParkeerplaatsen_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal parkeerplaatsen (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal parkeerplaatsen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal parkeerplaatsen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -299,7 +300,7 @@ ro_beg:MaximumAantalParkeerplaatsen_Omvang a skos:Concept ;
 ro_beg:MinimumAantalParkeerplaatsen_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal parkeerplaatsen (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal parkeerplaatsen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal parkeerplaatsen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -308,7 +309,7 @@ ro_beg:MinimumAantalParkeerplaatsen_Omvang a skos:Concept ;
 ro_beg:AantalRijstroken_Omvang a skos:Concept ;
   rdfs:label "Aantal rijstroken (Omvang)"@nl ;
   skos:prefLabel "Aantal rijstroken (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal rijstroken" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -317,7 +318,7 @@ ro_beg:AantalRijstroken_Omvang a skos:Concept ;
 ro_beg:MaximumAantalRijstroken_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal rijstroken (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal rijstroken (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal rijstroken" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -326,7 +327,7 @@ ro_beg:MaximumAantalRijstroken_Omvang a skos:Concept ;
 ro_beg:MinimumAantalRijstroken_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal rijstroken (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal rijstroken (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal rijstroken" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -335,7 +336,7 @@ ro_beg:MinimumAantalRijstroken_Omvang a skos:Concept ;
 ro_beg:AantalSporen_Omvang a skos:Concept ;
   rdfs:label "Aantal sporen (Omvang)"@nl ;
   skos:prefLabel "Aantal sporen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal sporen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -344,7 +345,7 @@ ro_beg:AantalSporen_Omvang a skos:Concept ;
 ro_beg:MaximumAantalSporen_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal sporen (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal sporen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal sporen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -353,7 +354,7 @@ ro_beg:MaximumAantalSporen_Omvang a skos:Concept ;
 ro_beg:MinimumAantalSporen_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal sporen (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal sporen (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal sporen" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -362,7 +363,7 @@ ro_beg:MinimumAantalSporen_Omvang a skos:Concept ;
 ro_beg:AantalWinkels_Omvang a skos:Concept ;
   rdfs:label "Aantal winkels (Omvang)"@nl ;
   skos:prefLabel "Aantal winkels (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal winkels" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -371,7 +372,7 @@ ro_beg:AantalWinkels_Omvang a skos:Concept ;
 ro_beg:MaximumAantalWinkels_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal winkels (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal winkels (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal winkels" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -380,7 +381,7 @@ ro_beg:MaximumAantalWinkels_Omvang a skos:Concept ;
 ro_beg:MinimumAantalWinkels_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal winkels (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal winkels (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal winkels" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -389,7 +390,7 @@ ro_beg:MinimumAantalWinkels_Omvang a skos:Concept ;
 ro_beg:AantalWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Aantal wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Aantal wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -398,7 +399,7 @@ ro_beg:AantalWooneenheden_Omvang a skos:Concept ;
 ro_beg:MaximumAantalWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -407,7 +408,7 @@ ro_beg:MaximumAantalWooneenheden_Omvang a skos:Concept ;
 ro_beg:MinimumAantalWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -416,7 +417,7 @@ ro_beg:MinimumAantalWooneenheden_Omvang a skos:Concept ;
 ro_beg:Maatvoering_Omvang a skos:Concept ;
   rdfs:label "Maatvoering (Omvang)"@nl ;
   skos:prefLabel "Maatvoering (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maatvoering" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -425,7 +426,7 @@ ro_beg:Maatvoering_Omvang a skos:Concept ;
 ro_beg:BebouwdOppervlak_m2_Omvang a skos:Concept ;
   rdfs:label "Bebouwd oppervlak (m2) (Omvang)"@nl ;
   skos:prefLabel "Bebouwd oppervlak (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "bebouwd oppervlak (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -434,7 +435,7 @@ ro_beg:BebouwdOppervlak_m2_Omvang a skos:Concept ;
 ro_beg:MaximumBebouwdOppervlak_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum bebouwd oppervlak (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum bebouwd oppervlak (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum bebouwd oppervlak (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -443,7 +444,7 @@ ro_beg:MaximumBebouwdOppervlak_m2_Omvang a skos:Concept ;
 ro_beg:MinimumBebouwdOppervlak_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum bebouwd oppervlak (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum bebouwd oppervlak (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum bebouwd oppervlak (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -452,7 +453,7 @@ ro_beg:MinimumBebouwdOppervlak_m2_Omvang a skos:Concept ;
 ro_beg:Breedte_m_Omvang a skos:Concept ;
   rdfs:label "Breedte (m) (Omvang)"@nl ;
   skos:prefLabel "Breedte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "breedte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -461,7 +462,7 @@ ro_beg:Breedte_m_Omvang a skos:Concept ;
 ro_beg:MaximumBreedte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum breedte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum breedte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum breedte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -470,7 +471,7 @@ ro_beg:MaximumBreedte_m_Omvang a skos:Concept ;
 ro_beg:MinimumBreedte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum breedte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum breedte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum breedte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -479,7 +480,7 @@ ro_beg:MinimumBreedte_m_Omvang a skos:Concept ;
 ro_beg:Dakhelling_graden_Omvang a skos:Concept ;
   rdfs:label "Dakhelling (graden) (Omvang)"@nl ;
   skos:prefLabel "Dakhelling (graden) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "dakhelling (graden)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -488,7 +489,7 @@ ro_beg:Dakhelling_graden_Omvang a skos:Concept ;
 ro_beg:MaximumDakhelling_graden_Omvang a skos:Concept ;
   rdfs:label "Maximum dakhelling (graden) (Omvang)"@nl ;
   skos:prefLabel "Maximum dakhelling (graden) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum dakhelling (graden)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -497,7 +498,7 @@ ro_beg:MaximumDakhelling_graden_Omvang a skos:Concept ;
 ro_beg:MinimumDakhelling_graden_Omvang a skos:Concept ;
   rdfs:label "Minimum dakhelling (graden) (Omvang)"@nl ;
   skos:prefLabel "Minimum dakhelling (graden) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum dakhelling (graden)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -506,7 +507,7 @@ ro_beg:MinimumDakhelling_graden_Omvang a skos:Concept ;
 ro_beg:Diepte_m_Omvang a skos:Concept ;
   rdfs:label "Diepte (m) (Omvang)"@nl ;
   skos:prefLabel "Diepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "diepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -515,7 +516,7 @@ ro_beg:Diepte_m_Omvang a skos:Concept ;
 ro_beg:MaximumDiepte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum diepte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum diepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum diepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -524,7 +525,7 @@ ro_beg:MaximumDiepte_m_Omvang a skos:Concept ;
 ro_beg:MinimumDiepte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum diepte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum diepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum diepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -533,7 +534,7 @@ ro_beg:MinimumDiepte_m_Omvang a skos:Concept ;
 ro_beg:Hoogte_m_Omvang a skos:Concept ;
   rdfs:label "Hoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Hoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "hoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -542,7 +543,7 @@ ro_beg:Hoogte_m_Omvang a skos:Concept ;
 ro_beg:MaximumHoogte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum hoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum hoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum hoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -551,7 +552,7 @@ ro_beg:MaximumHoogte_m_Omvang a skos:Concept ;
 ro_beg:MinimumHoogte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum hoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum hoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum hoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -560,7 +561,7 @@ ro_beg:MinimumHoogte_m_Omvang a skos:Concept ;
 ro_beg:Bouwhoogte_m_Omvang a skos:Concept ;
   rdfs:label "Bouwhoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Bouwhoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "bouwhoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -569,7 +570,7 @@ ro_beg:Bouwhoogte_m_Omvang a skos:Concept ;
 ro_beg:MaximumBouwhoogte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum bouwhoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum bouwhoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum bouwhoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -578,7 +579,7 @@ ro_beg:MaximumBouwhoogte_m_Omvang a skos:Concept ;
 ro_beg:MinimumBouwhoogte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum bouwhoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum bouwhoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum bouwhoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -587,7 +588,7 @@ ro_beg:MinimumBouwhoogte_m_Omvang a skos:Concept ;
 ro_beg:Goothoogte_m_Omvang a skos:Concept ;
   rdfs:label "Goothoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Goothoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "goothoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -596,7 +597,7 @@ ro_beg:Goothoogte_m_Omvang a skos:Concept ;
 ro_beg:MaximumGoothoogte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum goothoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum goothoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum goothoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -605,7 +606,7 @@ ro_beg:MaximumGoothoogte_m_Omvang a skos:Concept ;
 ro_beg:MinimumGoothoogte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum goothoogte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum goothoogte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum goothoogte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -614,7 +615,7 @@ ro_beg:MinimumGoothoogte_m_Omvang a skos:Concept ;
 ro_beg:HoogteliggingVlak_m_Omvang a skos:Concept ;
   rdfs:label "Hoogteligging vlak (m) (Omvang)"@nl ;
   skos:prefLabel "Hoogteligging vlak (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "hoogteligging vlak (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -623,7 +624,7 @@ ro_beg:HoogteliggingVlak_m_Omvang a skos:Concept ;
 ro_beg:MaximumHoogteliggingVlak_m_Omvang a skos:Concept ;
   rdfs:label "Maximum hoogteligging vlak (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum hoogteligging vlak (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum hoogteligging vlak (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -632,7 +633,7 @@ ro_beg:MaximumHoogteliggingVlak_m_Omvang a skos:Concept ;
 ro_beg:MinimumHoogteliggingVlak_m_Omvang a skos:Concept ;
   rdfs:label "Minimum hoogteligging vlak (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum hoogteligging vlak (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum hoogteligging vlak (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -641,7 +642,7 @@ ro_beg:MinimumHoogteliggingVlak_m_Omvang a skos:Concept ;
 ro_beg:Lengte_m_Omvang a skos:Concept ;
   rdfs:label "Lengte (m) (Omvang)"@nl ;
   skos:prefLabel "Lengte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "lengte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -650,7 +651,7 @@ ro_beg:Lengte_m_Omvang a skos:Concept ;
 ro_beg:MaximumLengte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum lengte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum lengte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum lengte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -659,7 +660,7 @@ ro_beg:MaximumLengte_m_Omvang a skos:Concept ;
 ro_beg:MinimumLengte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum lengte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum lengte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum lengte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -668,7 +669,7 @@ ro_beg:MinimumLengte_m_Omvang a skos:Concept ;
 ro_beg:Oppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Oppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Oppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "oppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -677,7 +678,7 @@ ro_beg:Oppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:MaximumOppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum oppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum oppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum oppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -686,7 +687,7 @@ ro_beg:MaximumOppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:MinimumOppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum oppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum oppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum oppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -695,7 +696,7 @@ ro_beg:MinimumOppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:Vloeroppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Vloeroppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Vloeroppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vloeroppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -704,7 +705,7 @@ ro_beg:Vloeroppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:Vloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
   rdfs:label "Vloeroppervlakte, bruto (m2) (Omvang)"@nl ;
   skos:prefLabel "Vloeroppervlakte, bruto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vloeroppervlakte, bruto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -713,7 +714,7 @@ ro_beg:Vloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
 ro_beg:Vloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
   rdfs:label "Vloeroppervlakte, netto (m2) (Omvang)"@nl ;
   skos:prefLabel "Vloeroppervlakte, netto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vloeroppervlakte, netto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -722,7 +723,7 @@ ro_beg:Vloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
 ro_beg:Vloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
   rdfs:label "Vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vloeroppervlakte; bvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -731,7 +732,7 @@ ro_beg:Vloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
 ro_beg:Vloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
   rdfs:label "Vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vloeroppervlakte; vvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -740,7 +741,7 @@ ro_beg:Vloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
 ro_beg:MaximumVloeroppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum vloeroppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum vloeroppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum vloeroppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -749,7 +750,7 @@ ro_beg:MaximumVloeroppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:MaximumVloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum vloeroppervlakte; bruto (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum vloeroppervlakte; bruto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum vloeroppervlakte; bruto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -758,7 +759,7 @@ ro_beg:MaximumVloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
 ro_beg:MaximumVloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum vloeroppervlakte; netto (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum vloeroppervlakte; netto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum vloeroppervlakte; netto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -767,7 +768,7 @@ ro_beg:MaximumVloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
 ro_beg:MaximumVloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum vloeroppervlakte; bvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -776,7 +777,7 @@ ro_beg:MaximumVloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
 ro_beg:MaximumVloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
   rdfs:label "Maximum vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Maximum vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum vloeroppervlakte; vvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -785,7 +786,7 @@ ro_beg:MaximumVloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
 ro_beg:MinimumVloeroppervlakte_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum vloeroppervlakte (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum vloeroppervlakte (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum vloeroppervlakte (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -794,7 +795,7 @@ ro_beg:MinimumVloeroppervlakte_m2_Omvang a skos:Concept ;
 ro_beg:MinimumVloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum vloeroppervlakte; bruto (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum vloeroppervlakte; bruto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum vloeroppervlakte; bruto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -803,7 +804,7 @@ ro_beg:MinimumVloeroppervlakte_Bruto_m2_Omvang a skos:Concept ;
 ro_beg:MinimumVloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum vloeroppervlakte; netto (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum vloeroppervlakte; netto (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum vloeroppervlakte; netto (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -812,7 +813,7 @@ ro_beg:MinimumVloeroppervlakte_Netto_m2_Omvang a skos:Concept ;
 ro_beg:MinimumVloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum vloeroppervlakte; bvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum vloeroppervlakte; bvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -821,7 +822,7 @@ ro_beg:MinimumVloeroppervlakte_Bvo_m2_Omvang a skos:Concept ;
 ro_beg:MinimumVloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
   rdfs:label "Minimum vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
   skos:prefLabel "Minimum vloeroppervlakte; vvo (m2) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum vloeroppervlakte; vvo (m2)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -830,7 +831,7 @@ ro_beg:MinimumVloeroppervlakte_Vvo_m2_Omvang a skos:Concept ;
 ro_beg:Volume_m3_Omvang a skos:Concept ;
   rdfs:label "Volume (m3) (Omvang)"@nl ;
   skos:prefLabel "Volume (m3) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "volume (m3)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -839,7 +840,7 @@ ro_beg:Volume_m3_Omvang a skos:Concept ;
 ro_beg:MaximumVolume_m3_Omvang a skos:Concept ;
   rdfs:label "Maximum volume (m3) (Omvang)"@nl ;
   skos:prefLabel "Maximum volume (m3) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum volume (m3)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -848,7 +849,7 @@ ro_beg:MaximumVolume_m3_Omvang a skos:Concept ;
 ro_beg:MinimumVolume_m3_Omvang a skos:Concept ;
   rdfs:label "Minimum volume (m3) (Omvang)"@nl ;
   skos:prefLabel "Minimum volume (m3) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum volume (m3)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -857,7 +858,7 @@ ro_beg:MinimumVolume_m3_Omvang a skos:Concept ;
 ro_beg:Bebouwingspercentage_p_Omvang a skos:Concept ;
   rdfs:label "Bebouwingspercentage (%) (Omvang)"@nl ;
   skos:prefLabel "Bebouwingspercentage (%) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "bebouwingspercentage (%)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -866,7 +867,7 @@ ro_beg:Bebouwingspercentage_p_Omvang a skos:Concept ;
 ro_beg:MaximumBebouwingspercentage_p_Omvang a skos:Concept ;
   rdfs:label "Maximum bebouwingspercentage (%) (Omvang)"@nl ;
   skos:prefLabel "Maximum bebouwingspercentage (%) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum bebouwingspercentage (%)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -875,7 +876,7 @@ ro_beg:MaximumBebouwingspercentage_p_Omvang a skos:Concept ;
 ro_beg:MinimumBebouwingspercentage_p_Omvang a skos:Concept ;
   rdfs:label "Minimum bebouwingspercentage (%) (Omvang)"@nl ;
   skos:prefLabel "Minimum bebouwingspercentage (%) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum bebouwingspercentage (%)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -884,7 +885,7 @@ ro_beg:MinimumBebouwingspercentage_p_Omvang a skos:Concept ;
 ro_beg:AantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "aantal aaneen te bouwen wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -893,7 +894,7 @@ ro_beg:AantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
 ro_beg:MaximumAantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Maximum aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Maximum aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum aantal aaneen te bouwen wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -902,7 +903,7 @@ ro_beg:MaximumAantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
 ro_beg:MinimumAantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
   rdfs:label "Minimum aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
   skos:prefLabel "Minimum aantal aaneen te bouwen wooneenheden (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum aantal aaneen te bouwen wooneenheden" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -911,7 +912,7 @@ ro_beg:MinimumAantalAaneenTeBouwenWooneenheden_Omvang a skos:Concept ;
 ro_beg:VerticaleBouwdiepte_m_Omvang a skos:Concept ;
   rdfs:label "Verticale bouwdiepte (m) (Omvang)"@nl ;
   skos:prefLabel "Verticale bouwdiepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "verticale bouwdiepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -920,7 +921,7 @@ ro_beg:VerticaleBouwdiepte_m_Omvang a skos:Concept ;
 ro_beg:MaximumVerticaleBouwdiepte_m_Omvang a skos:Concept ;
   rdfs:label "Maximum verticale bouwdiepte (m) (Omvang)"@nl ;
   skos:prefLabel "Maximum verticale bouwdiepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "maximum verticale bouwdiepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -929,7 +930,7 @@ ro_beg:MaximumVerticaleBouwdiepte_m_Omvang a skos:Concept ;
 ro_beg:MinimumVerticaleBouwdiepte_m_Omvang a skos:Concept ;
   rdfs:label "Minimum verticale bouwdiepte (m) (Omvang)"@nl ;
   skos:prefLabel "Minimum verticale bouwdiepte (m) (Omvang)"@nl ;
-  skos:broader ro_beg:Omvang ;
+  skos-thes:broaderGeneric ro_beg:Omvang ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "minimum verticale bouwdiepte (m)" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -946,7 +947,7 @@ ro_beg:Gebiedsaanduiding a skos:Concept ;
 ro_beg:Geluidzone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Geluidzone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Geluidzone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "geluidzone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -955,7 +956,7 @@ ro_beg:Geluidzone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Luchtvaartverkeerzone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Luchtvaartverkeerzone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Luchtvaartverkeerzone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "luchtvaartverkeerzone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -964,7 +965,7 @@ ro_beg:Luchtvaartverkeerzone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Milieuzone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Milieuzone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Milieuzone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "milieuzone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -973,7 +974,7 @@ ro_beg:Milieuzone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Reconstructiewetzone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Reconstructiewetzone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Reconstructiewetzone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "reconstructiewetzone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -982,7 +983,7 @@ ro_beg:Reconstructiewetzone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Veiligheidszone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Veiligheidszone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Veiligheidszone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "veiligheidszone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -991,7 +992,7 @@ ro_beg:Veiligheidszone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Vrijwaringszone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Vrijwaringszone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Vrijwaringszone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "vrijwaringszone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -1000,7 +1001,7 @@ ro_beg:Vrijwaringszone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:Wetgevingzone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Wetgevingzone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Wetgevingzone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "wetgevingzone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -1009,7 +1010,7 @@ ro_beg:Wetgevingzone_Gebiedsaanduiding a skos:Concept ;
 ro_beg:OverigeZone_Gebiedsaanduiding a skos:Concept ;
   rdfs:label "Overige zone (Gebiedsaanduiding)"@nl ;
   skos:prefLabel "Overige zone (Gebiedsaanduiding)"@nl ;
-  skos:broader ro_beg:Gebiedsaanduiding ;
+  skos-thes:broaderGeneric ro_beg:Gebiedsaanduiding ;
   skos:inScheme ro_begkr:ro ;
   skos:notation "overige zone" ;
   dcterms:source <http://www.geonovum.nl/wegwijzer/standaarden/informatiemodel-ruimtelijke-ordening-imro2012>
@@ -1075,7 +1076,7 @@ ro_beg:Concept_Planstatus a skos:Concept ;
   skos:prefLabel "Concept"@nl ;
   skos:definition "TODO"@nl ;
   skos:inScheme ro_begkr:ro ;
-  skos:broader ro_beg:Planstatus ;
+  skos-thes:broaderGeneric ro_beg:Planstatus ;
   skos:notation "concept"
 .
 
@@ -1084,7 +1085,7 @@ ro_beg:Voorontwerp_Planstatus a skos:Concept ;
   skos:prefLabel "Voorontwerp"@nl ;
   skos:definition "TODO"@nl ;
   skos:inScheme ro_begkr:ro ;
-  skos:broader ro_beg:Planstatus ;
+  skos-thes:broaderGeneric ro_beg:Planstatus ;
   skos:notation "voorontwerp"
 .
 
@@ -1093,7 +1094,7 @@ ro_beg:Ontwerp_Planstatus a skos:Concept ;
   skos:prefLabel "Ontwerp"@nl ;
   skos:definition "TODO"@nl ;
   skos:inScheme ro_begkr:ro ;
-  skos:broader ro_beg:Planstatus ;
+  skos-thes:broaderGeneric ro_beg:Planstatus ;
   skos:notation "ontwerp"
 .
 
@@ -1102,7 +1103,7 @@ ro_beg:Vastgesteld_Planstatus a skos:Concept ;
   skos:prefLabel "Vastgesteld"@nl ;
   skos:definition "TODO"@nl ;
   skos:inScheme ro_begkr:ro ;
-  skos:broader ro_beg:Planstatus ;
+  skos-thes:broaderGeneric ro_beg:Planstatus ;
   skos:notation "vastgesteld"
 .
 
@@ -1111,7 +1112,7 @@ ro_beg:Geconsolideerd_Planstatus a skos:Concept ;
   skos:prefLabel "Geconsolideerd"@nl ;
   skos:definition "TODO"@nl ;
   skos:inScheme ro_begkr:ro ;
-  skos:broader ro_beg:Planstatus ;
+  skos-thes:broaderGeneric ro_beg:Planstatus ;
   skos:notation "geconsolideerd"
 .
 
@@ -1139,27 +1140,27 @@ ro_beg:Norm a skos:Concept ;
 ro_beg:IMRO2012 a skos:Concept ;
   rdfs:label "IMRO2012"@nl ;
   skos:prefLabel "IMRO2012"@nl ;
-  skos:broader ro_beg:Norm ;
+  skos-thes:broaderGeneric ro_beg:Norm ;
   skos:notation "IMRO2012"
 .
 
 ro_beg:PRBP2012 a skos:Concept ;
   rdfs:label "PRBP2012"@nl ;
   skos:prefLabel "PRBP2012"@nl ;
-  skos:broader ro_beg:Norm ;
+  skos-thes:broaderGeneric ro_beg:Norm ;
   skos:notation "PRBP2012"
 .
 
 ro_beg:IMROPT2012 a skos:Concept ;
   rdfs:label "IMROPT2012"@nl ;
   skos:prefLabel "IMROPT2012"@nl ;
-  skos:broader ro_beg:Norm ;
+  skos-thes:broaderGeneric ro_beg:Norm ;
   skos:notation "IMROPT2012"
 .
 
 ro_beg:PRABPK2012 a skos:Concept ;
   rdfs:label "PRABPK2012"@nl ;
   skos:prefLabel "PRABPK2012"@nl ;
-  skos:broader ro_beg:Norm ;
+  skos-thes:broaderGeneric ro_beg:Norm ;
   skos:notation "PRABPK2012"
 .

--- a/catalogusdata/Kenniskluis/Concepten Tax A.ttl
+++ b/catalogusdata/Kenniskluis/Concepten Tax A.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix tax: <http://pdok-ld-gck.fto.kadaster.nl/id/concept/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.
 @prefix rdf: <http://www.w3.org/1999/02/022-rdf-syntax-ns#>.

--- a/catalogusdata/Kenniskluis/Concepten Tax O.ttl
+++ b/catalogusdata/Kenniskluis/Concepten Tax O.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix tax: <http://pdok-ld-gck.so.kadaster.nl/id/concept/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.
 @prefix rdf: <http://www.w3.org/1999/02/022-rdf-syntax-ns#>.

--- a/catalogusdata/Kenniskluis/Concepten Tax P.ttl
+++ b/catalogusdata/Kenniskluis/Concepten Tax P.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix tax: <http://pdok-ld-gck.cs.kadaster.nl/id/concept/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.
 @prefix rdf: <http://www.w3.org/1999/02/022-rdf-syntax-ns#>.

--- a/catalogusdata/Kenniskluis/Concepten Tax T.ttl
+++ b/catalogusdata/Kenniskluis/Concepten Tax T.ttl
@@ -1,4 +1,4 @@
-﻿@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix tax: <http://pdok-ld-gck.in.kadaster.nl/id/concept/>.
 @prefix brt: <http://brt.basisregistraties.overheid.nl/id/begrip/>.
 @prefix rdf: <http://www.w3.org/1999/02/022-rdf-syntax-ns#>.

--- a/catalogusdata/Kenniskluis/Testdata Tax A.ttl
+++ b/catalogusdata/Kenniskluis/Testdata Tax A.ttl
@@ -1,4 +1,4 @@
-﻿@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix concept:	<http://pdok-ld-gck.fto.kadaster.nl/id/begrip/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/catalogusdata/Kenniskluis/Testdata Tax O.ttl
+++ b/catalogusdata/Kenniskluis/Testdata Tax O.ttl
@@ -1,4 +1,4 @@
-﻿@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix concept:	<http://pdok-ld-gck.so.kadaster.nl/id/begrip/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/catalogusdata/Kenniskluis/Testdata Tax P.ttl
+++ b/catalogusdata/Kenniskluis/Testdata Tax P.ttl
@@ -1,4 +1,4 @@
-﻿@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix concept:	<http://pdok-ld-gck.cs.kadaster.nl/id/begrip/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/catalogusdata/Kenniskluis/Testdata Tax T.ttl
+++ b/catalogusdata/Kenniskluis/Testdata Tax T.ttl
@@ -1,4 +1,4 @@
-﻿@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix concept:	<http://pdok-ld-gck.in.kadaster.nl/id/begrip/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .

--- a/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument A.xml
+++ b/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument A.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#">
+<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#" xmlns:skoslex="http://bp4mc2.org/def/skos-lex/">
 	<begrip about="http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/Bouwwerk">
         <term>bouwwerk</term>
         <definitie>constructie van enige omvang van hout, steen, metaal of ander materiaal, die op de plaats van bestemming hetzij direct of indirect met de grond verbonden is, hetzij direct of indirect steun vindt in of op de grond, bedoeld om ter plaatse te functioneren, met inbegrip van de daarvan deel uitmakende bouwwerkgebonden installaties</definitie>
@@ -7,5 +7,9 @@
 	<begrip about="http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/Gebouw">
         <term>gebouw</term>
         <definitie><inline property="thes:broaderGeneric" href="http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> dat een voor mensen toegankelijke overdekte geheel of gedeeltelijk met wanden omsloten ruimte vormt</definitie>
+	</begrip>
+	<begrip about="http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/BrandveiligGebruiksactiviteit">
+		<term>brandveilig gebruiksactiviteit</term>
+		<definitie>activiteit inhoudende het in gebruik nemen of gebruiken van een <inline property="skoslex:object" href="http://data.acceptatie.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> waarbij de brandveiligheid in het bijzonder van belang is</definitie>
 	</begrip>
 </toestand>

--- a/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument O.xml
+++ b/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument O.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#">
+<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#" xmlns:skoslex="http://bp4mc2.org/def/skos-lex/">
 	<begrip about="http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/Bouwwerk">
         <term>bouwwerk</term>
         <definitie>constructie van enige omvang van hout, steen, metaal of ander materiaal, die op de plaats van bestemming hetzij direct of indirect met de grond verbonden is, hetzij direct of indirect steun vindt in of op de grond, bedoeld om ter plaatse te functioneren, met inbegrip van de daarvan deel uitmakende bouwwerkgebonden installaties</definitie>
@@ -7,5 +7,9 @@
 	<begrip about="http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/Gebouw">
         <term>gebouw</term>
         <definitie><inline property="thes:broaderGeneric" href="http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> dat een voor mensen toegankelijke overdekte geheel of gedeeltelijk met wanden omsloten ruimte vormt</definitie>
+	</begrip>
+	<begrip about="http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/BrandveiligGebruiksactiviteit">
+		<term>brandveilig gebruiksactiviteit</term>
+		<definitie>activiteit inhoudende het in gebruik nemen of gebruiken van een <inline property="skoslex:object" href="http://data.ontwikkeling.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> waarbij de brandveiligheid in het bijzonder van belang is</definitie>
 	</begrip>
 </toestand>

--- a/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument T.xml
+++ b/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument T.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#">
+<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#" xmlns:skoslex="http://bp4mc2.org/def/skos-lex/">
 	<begrip about="http://data.test.pdok.nl/catalogus/dso/id/concept/Bouwwerk">
         <term>bouwwerk</term>
         <definitie>constructie van enige omvang van hout, steen, metaal of ander materiaal, die op de plaats van bestemming hetzij direct of indirect met de grond verbonden is, hetzij direct of indirect steun vindt in of op de grond, bedoeld om ter plaatse te functioneren, met inbegrip van de daarvan deel uitmakende bouwwerkgebonden installaties</definitie>
@@ -7,5 +7,9 @@
 	<begrip about="http://data.test.pdok.nl/catalogus/dso/id/concept/Gebouw">
         <term>gebouw</term>
         <definitie><inline property="thes:broaderGeneric" href="http://data.test.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> dat een voor mensen toegankelijke overdekte geheel of gedeeltelijk met wanden omsloten ruimte vormt</definitie>
+	</begrip>
+	<begrip about="http://data.test.pdok.nl/catalogus/dso/id/concept/BrandveiligGebruiksactiviteit">
+		<term>brandveilig gebruiksactiviteit</term>
+		<definitie>activiteit inhoudende het in gebruik nemen of gebruiken van een <inline property="skoslex:object" href="http://data.test.pdok.nl/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> waarbij de brandveiligheid in het bijzonder van belang is</definitie>
 	</begrip>
 </toestand>

--- a/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument local.xml
+++ b/catalogusdata/Omgevingsdocumenten/Testdata omgevingsdocument local.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#">
+<toestand xmlns="http://www.overheid.nl/namespaces/stop#" xmlns:thes="http://purl.org/iso25964/skos-thes#" xmlns:skoslex="http://bp4mc2.org/def/skos-lex/">
 	<begrip about="http://localhost:8080/catalogus/dso/id/concept/Bouwwerk">
         <term>bouwwerk</term>
         <definitie>constructie van enige omvang van hout, steen, metaal of ander materiaal, die op de plaats van bestemming hetzij direct of indirect met de grond verbonden is, hetzij direct of indirect steun vindt in of op de grond, bedoeld om ter plaatse te functioneren, met inbegrip van de daarvan deel uitmakende bouwwerkgebonden installaties</definitie>
@@ -7,5 +7,9 @@
 	<begrip about="http://localhost:8080/catalogus/dso/id/concept/Gebouw">
         <term>gebouw</term>
         <definitie><inline property="thes:broaderGeneric" href="http://localhost:8080/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> dat een voor mensen toegankelijke overdekte geheel of gedeeltelijk met wanden omsloten ruimte vormt</definitie>
+	</begrip>
+	<begrip about="http://localhost:8080/catalogus/dso/id/concept/BrandveiligGebruiksactiviteit">
+		<term>brandveilig gebruiksactiviteit</term>
+		<definitie>activiteit inhoudende het in gebruik nemen of gebruiken van een <inline property="skoslex:object" href="http://localhost:8080/catalogus/dso/id/concept/Bouwwerk">bouwwerk</inline> waarbij de brandveiligheid in het bijzonder van belang is</definitie>
 	</begrip>
 </toestand>


### PR DESCRIPTION
De toeleidingsbegrippen zijn toegevoegd aan de tabel, daarbij rest nog de vraag of het bijhouden van historie nodig is? (In overleg met Wessel bekeken hoe de date filters daarvoor van toepassing zijn).
Verder heb ik een tweede toeleidingsbegrip in de local dataset gezet om te verifiëren of meerdere toeleidingsbegrippen netjes onder elkaar worden gezet. 